### PR TITLE
Authentication panics when audience field is empty

### DIFF
--- a/src/jwt_util.rs
+++ b/src/jwt_util.rs
@@ -78,10 +78,19 @@ pub(crate) async fn validate_jwt(client: &Client, token: &str) -> EsiResult<Toke
             "JWT issuer is incorrect",
         )));
     }
-    if token.claims["aud"].as_str().unwrap() != "EVE Online" {
-        return Err(EsiError::InvalidJWT(String::from(
-            "JWT audience field is incorrect",
-        )));
+    match token.claims["aud"].as_str() {
+        Some(aud) => {
+            if aud != "EVE Online" {
+                return Err(EsiError::InvalidJWT(String::from(
+                    "JWT audience field is incorrect",
+                )));
+            }
+        },
+        None => {
+            return Err(EsiError::InvalidJWT(String::from(
+                "JWT audience field is incorrect",
+            )));
+        }
     }
     let token_claims = serde_json::from_value(token.claims)?;
     Ok(token_claims)


### PR DESCRIPTION
I have experimented an error trying to authenticate new users into ESI and for some reason the AUDience field its empty, making rfesi to panic without any emaninful message.


I'm adding a validation for such situation