### PR TITLE
Cloneable structs

### DIFF
--- a/src/groups/industry.rs
+++ b/src/groups/industry.rs
@@ -7,14 +7,14 @@ pub struct IndustryGroup<'a> {
     pub(crate) esi: &'a Esi,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[allow(missing_docs)]
 pub struct CostIndex {
     pub activity: String,
     pub cost_index: f32,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[allow(missing_docs)]
 pub struct IndustrialSystem {
     pub cost_indices: Vec<CostIndex>,

--- a/src/groups/market.rs
+++ b/src/groups/market.rs
@@ -2,7 +2,7 @@
 
 use crate::prelude::*;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[allow(missing_docs)]
 pub struct HistoryItem {
     pub average: f64,
@@ -30,7 +30,7 @@ pub struct MarketOrder {
     pub volume_total: i32,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[allow(missing_docs)]
 pub struct PriceItem {
     pub adjusted_price: Option<f64>,

--- a/src/groups/search.rs
+++ b/src/groups/search.rs
@@ -21,7 +21,7 @@ impl<'a> SearchGroup<'a> {
     );
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[allow(missing_docs)]
 pub struct SearchResult {
     pub agent: Option<Vec<i32>>,

--- a/src/groups/universe.rs
+++ b/src/groups/universe.rs
@@ -15,7 +15,7 @@ pub struct Position {
     pub z: f64,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[allow(missing_docs)]
 pub struct Constellation {
     pub constellation_id: i32,
@@ -25,7 +25,7 @@ pub struct Constellation {
     pub systems: Vec<i32>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[allow(missing_docs)]
 pub struct Region {
     pub constellations: Vec<i32>,
@@ -34,7 +34,7 @@ pub struct Region {
     pub region_id: i32,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[allow(missing_docs)]
 pub struct SystemPlanet {
     pub asteroid_belts: Option<Vec<i32>>,
@@ -42,7 +42,7 @@ pub struct SystemPlanet {
     pub planet_id: i32,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[allow(missing_docs)]
 pub struct System {
     pub constellation_id: i32,
@@ -76,21 +76,21 @@ pub struct Category {
     pub name: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[allow(missing_docs)]
 pub struct TypeDogmaAttribute {
     pub attribute_id: i32,
     pub value: f64,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[allow(missing_docs)]
 pub struct TypeDogmaEffect {
     pub effect_id: i32,
     pub is_default: bool,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[allow(missing_docs)]
 pub struct Type {
     pub capacity: Option<f64>,
@@ -128,7 +128,7 @@ pub struct Station {
     pub type_id: i32,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[allow(missing_docs)]
 pub struct Structure {
     pub name: String,

--- a/src/groups/universe.rs
+++ b/src/groups/universe.rs
@@ -7,7 +7,7 @@ pub struct UniverseGroup<'a> {
     pub(crate) esi: &'a Esi,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[allow(missing_docs)]
 pub struct Position {
     pub x: f64,
@@ -111,7 +111,7 @@ pub struct Type {
     pub volume: Option<f64>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[allow(missing_docs)]
 pub struct Station {
     pub max_dockable_ship_volume: f64,


### PR DESCRIPTION
I've added a few traits I need to build a cache in front of your API: 

Serialize - To save the structs on disk
Clone - To get a owned struct from a RWLock<HashMap<u64, Stations>> (and other similar types )