### PR TITLE
Location - Correct ID Types

### DIFF
--- a/src/groups/location.rs
+++ b/src/groups/location.rs
@@ -8,8 +8,8 @@ pub struct LocationGroup<'a> {
 #[derive(Debug, Deserialize)]
 #[allow(missing_docs)]
 pub struct LocationInfo {
-    pub solar_system_id: u64,
-    pub station_id: Option<u64>,
+    pub solar_system_id: i32,
+    pub station_id: Option<i32>,
     pub structure_id: Option<u64>,
 }
 
@@ -18,7 +18,7 @@ pub struct LocationInfo {
 pub struct OnlineStatus {
     pub last_login: Option<String>,
     pub last_logout: Option<String>,
-    pub logins: Option<u64>,
+    pub logins: Option<i32>,
     pub online: bool,
 }
 
@@ -27,7 +27,7 @@ pub struct OnlineStatus {
 pub struct CurrentShip {
     pub ship_item_id: u64,
     pub ship_name: String,
-    pub ship_type_id: u64,
+    pub ship_type_id: i32,
 }
 
 impl<'a> LocationGroup<'a> {


### PR DESCRIPTION
I've corrected some id types according to what's define in the eve esi: https://esi.evetech.net/ui/#/Location

Have you noticed that a lot of the types returned are actually i64 instead of u64 (Structure IDs for example) ? I don't expect any negative identifier, but should we change them just to be safe ?