### PR TITLE
Adding default-tls and rustls-tls features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,10 @@ chrono = "0.4.31"
 uuid = { version = "1.5.0", features = ["v4", "fast-rng"] }
 
 [features]
-default = ["random_state", "validate_jwt", "reqwest/default-tls"]
+default = ["random_state", "validate_jwt", "default-tls"]
 random_state = []
 validate_jwt = ["dep:jsonwebtoken"]
-rustls = ["reqwest/rustls-tls"]
+default-tls = ["reqwest/default-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
+
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,3 @@ random_state = []
 validate_jwt = ["dep:jsonwebtoken"]
 default-tls = ["reqwest/default-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
-
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ http = "1.1.0"
 jsonwebtoken = { version = "9.1.0", optional = true }
 log = "0.4.20"
 rand = "0.8.5"
-reqwest = { version = "0.12.5", features = ["json"] }
+reqwest = { version = "0.12.5", default-features = false, features = ["json", "charset", "http2", "macos-system-configuration"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 sha2 = "0.10.8"
@@ -33,6 +33,8 @@ chrono = "0.4.31"
 uuid = { version = "1.5.0", features = ["v4", "fast-rng"] }
 
 [features]
-default = ["random_state", "validate_jwt"]
+default = ["random_state", "validate_jwt", "reqwest/default-tls"]
 random_state = []
 validate_jwt = ["dep:jsonwebtoken"]
+rustls = ["reqwest/rustls-tls"]
+

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't want or need random SSO state string generation, you can disable th
 
 If you don't want or need SSO token verification, you can disable the "validate_jwt" feature.
 
-if you don't want to use [Rustls](https://crates.io/crates/rustls) instead of OpenSSL to make request, you can enable "rustls" feature.
+if you don't want to use [Rustls](https://crates.io/crates/rustls) instead of OpenSSL to make request, you can enable "rustls-tls" feature, otherwise enable "default-tls" feature.
 
 ## Using
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ If you don't want or need random SSO state string generation, you can disable th
 
 If you don't want or need SSO token verification, you can disable the "validate_jwt" feature.
 
+if you don't want to use [Rustls](https://crates.io/crates/rustls) instead of OpenSSL to make request, you can enable "rustls" feature.
+
 ## Using
 
 [Docs link](https://docs.rs/rfesi).

--- a/README.md
+++ b/README.md
@@ -13,11 +13,9 @@ Add the latest version to your `Cargo.toml`.
 
 This crate has several features that are enabled by default.
 
-If you don't want or need random SSO state string generation, you can disable the "random_state" feature.
-
-If you don't want or need SSO token verification, you can disable the "validate_jwt" feature.
-
-if you don't want to use [Rustls](https://crates.io/crates/rustls) instead of OpenSSL to make request, you can enable "rustls-tls" feature, otherwise enable "default-tls" feature.
+- If you don't want or need random SSO state string generation, you can disable the "random_state" feature.
+- If you don't want or need SSO token verification, you can disable the "validate_jwt" feature.
+- If you prefer to use [rustls](https://crates.io/crates/rustls) instead of your system's TLS implementation ([more info here](https://docs.rs/reqwest/latest/reqwest/tls/)) to make requests, you can disable the default features and add the "rustls-tls" feature.
 
 ## Using
 

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -219,9 +219,17 @@ impl EsiBuilder {
             );
             map
         };
+        #[cfg(not(feature = "rustls-tls"))]
         let client = Client::builder()
             .timeout(http_timeout)
             .default_headers(headers)
+            .build()?;
+
+        #[cfg(feature = "rustls-tls")]
+        let client = Client::builder()
+            .timeout(http_timeout)
+            .default_headers(headers)
+            .use_rustls_tls()
             .build()?;
         Ok(client)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,9 @@
 #![deny(missing_docs)]
 
 #[cfg(all(feature = "default-tls", feature = "rustls-tls"))]
-compile_error!("feature \"default-tls\" and feature \"rustls-tls\" cannot be enabled at the same time");
+compile_error!(
+    "feature \"default-tls\" and feature \"rustls-tls\" cannot be enabled at the same time"
+);
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,9 @@
 #![deny(clippy::all)]
 #![deny(missing_docs)]
 
+#[cfg(all(feature = "default-tls", feature = "rustls-tls"))]
+compile_error!("feature \"default-tls\" and feature \"rustls-tls\" cannot be enabled at the same time");
+
 #[macro_use]
 mod macros;
 


### PR DESCRIPTION
I'm creating two features:

default-tls: uses OpenSSL as the reqwest backend to send and recieve all requests. Enabled by default (this was the default behavior until now).

rustls-tls: Uses rustls as the reqwest backend to send and recieve all requests.

adding a small validation top avoid enabling both features at the same time (this could me better in a more elegant way, but for now its Ok)

Reason to do this: Avoid using unsafe code.