### PR TITLE
Enforce ESI error limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 *.spec.json
+/.idea

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,7 @@
 //! Errors
 
+use std::num::ParseIntError;
+use http::header::ToStrError;
 use thiserror::Error;
 
 /// Errors that can occur when dealing with ESI.
@@ -57,6 +59,15 @@ pub enum EsiError {
     /// Error for being unable to get the current timestamp.
     #[error("Could not get current timestamp: {0}")]
     Timestamp(#[from] std::time::SystemTimeError),
+    /// Error for being unable to read response header.
+    #[error("Could not read response header value: {0}")]
+    HeaderReadError(#[from] ToStrError),
+    /// Error for being unable to parse header value.
+    #[error("Could not parse response header - {0}: {1}")]
+    HeaderParseError(String, ParseIntError),
+    /// Error for enforcing ESI error limit
+    #[error("Refusing to process request as we are error limited for {0}ms")]
+    ErrorLimited(i64),
     /// Error for the access token being used after expiring (and therefore
     /// being unable to be used for ESI) and no refresh token being present
     /// to fetch another access token.


### PR DESCRIPTION
This PR should make sure that rfesi does not violate ESI's error limits, which could potentially result in a ban from ESI.
I wrote this PR because I feel like it would be risky to use the ESI for my use-case without it.

Every response has its headers checked. The state of the last response is stored in a Cell.

While the limit is reached, the client should refuse to send more requests. The limit expires automatically. I have only tested this functionality via the tests provided, not on the actual ESI server yet.

The new public function `is_error_limited` returns an enum indicating whether the client is limited, and for how long.

PS: I also intend to expose headers down the line, which could resolve #34