### PR TITLE
Use Arc<RwLock<T>> to make Esi implement Sync again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 sha2 = "0.10.9"
 thiserror = "1.0.69"
+tokio = "1"
 
 [dev-dependencies]
 pretty_env_logger = "0.5.0"


### PR DESCRIPTION
Over this weekend I had my first foray into concurrent Rust when I integrated this library into a webserver. It quickly occurred to me that my changes in #47 made Esi lose the `Sync` trait. Oops!

This PR replaces `Cell<T>` with `Arc<tokio::sync::RwLock<T>>`. The `Arc` is there to support the `Clone` trait.

This has the breaking change that `is_error_limited` now returns a future. I did consider using an `AtomicU64` instead, but ultimately went with this solution out of portability concerns.

Tokio is brought into scope for `tokio::sync::RwLock`. Prior to this change, Tokio was already a transitive dependency.
