### PR TITLE
Add support for endpoint-specific headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rfesi"
-version = "0.49.1"
+version = "0.50.0"
 authors = ["Celeo <mattboulanger@fastmail.com>"]
 edition = "2021"
 description = "Rust API for EVE Online's ESI"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,6 +37,9 @@ pub enum EsiError {
     /// Error for if the provided user-agent header value has invalid characters.
     #[error("Invalid HTTP header value")]
     InvalidUserAgentHeader(#[from] http::header::InvalidHeaderValue),
+    /// Error for if the provided user-agent header name has invalid characters.
+    #[error("Invalid HTTP header name")]
+    InvalidHeaderName(#[from] http::header::InvalidHeaderName),
     /// Error for if the underlying `reqwest::Client` could not be constructed.
     #[error("Error constructing HTTP client")]
     ReqwestError(#[from] reqwest::Error),

--- a/src/groups/user_interface.rs
+++ b/src/groups/user_interface.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use std::collections::HashMap;
 
 /// Endpoints for UserInterface
 pub struct UserInterfaceGroup<'a> {
@@ -9,17 +10,25 @@ impl UserInterfaceGroup<'_> {
     /// Open the market details window.
     pub async fn open_market_details_window(
         &self,
-        character_id: u64,
         type_id: i32,
+        compatibility_date: &str,
     ) -> EsiResult<()> {
         // not using the macro since it doesn't like no body
         let path = self
             .esi
             .get_endpoint_for_op_id("post_ui_openwindow_marketdetails")?
-            .replace("{character_id}", &character_id.to_string())
             .replace("{type_id}", &type_id.to_string());
+        let mut headers = HashMap::new();
+        headers.insert("X-Compatibility-Date", compatibility_date.to_string());
         self.esi
-            .query("POST", RequestType::Authenticated, &path, None, None)
+            .query(
+                "POST",
+                RequestType::Authenticated,
+                &path,
+                None,
+                None,
+                Some(headers),
+            )
             .await
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,7 +30,7 @@
 /// pub async fn function_name(&self) -> EsiResult<Vec<u64>> {
 ///     let path = self.esi.get_endpoint_for_op_id("some_operation_id")?;
 ///     self.esi
-///         .query("GET", RequestType::Public, &path, None, None)
+///         .query("GET", RequestType::Public, &path, None, None, None)
 ///         .await
 /// }
 /// ```
@@ -69,7 +69,7 @@
 ///     let path = self.esi.get_endpoint_for_op_id("some_operation_id")?
 ///         .replace("{alliance_id}", &alliance_id.to_string());
 ///     self.esi
-///         .query("GET", RequestType::Public, &path, None, None)
+///         .query("GET", RequestType::Public, &path, None, None, None)
 ///         .await
 /// }
 /// ```
@@ -144,7 +144,7 @@ macro_rules! api_get {
                     .replace($replace, &$param.to_string())
                 )*;
             self.esi.
-                query("GET", $visibility, &path, None, None)
+                query("GET", $visibility, &path, None, None, None)
                 .await
         }
     };
@@ -186,7 +186,7 @@ macro_rules! api_get {
             )?
             let params: Vec<(&str, &str)> = params.iter().map(|(a, b)| (*a, &**b)).collect();
             self.esi.
-                query("GET", $visibility, &path, Some(&params), None)
+                query("GET", $visibility, &path, Some(&params), None, None)
                 .await
         }
     };
@@ -234,7 +234,7 @@ macro_rules! api_get {
 ///         .replace("{alliance_id}", &alliance_id.to_string());
 ///     let body = serde_json::to_string(ids);
 ///     self.esi
-///         .query("GET", RequestType::Public, &path, None, Some(&body))
+///         .query("GET", RequestType::Public, &path, None, Some(&body), None)
 ///         .await
 /// }
 /// ```
@@ -259,7 +259,7 @@ macro_rules! api_post {
                 )*;
             let body = serde_json::to_string($body_param)?;
             self.esi.
-                query("POST", $visibility, &path, None, Some(&body))
+                query("POST", $visibility, &path, None, Some(&body), None)
                 .await
         }
     }


### PR DESCRIPTION
Fixes #50 (again)

I'm not actually adding support for the headers in the `api_get!`/`api_post!` macros; unless/until a lot of endpoints require these, there isn't sense in me having to face the horrors of macros again. :)